### PR TITLE
UI improvements and GitHub Pages routing fix

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,30 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="/favicon.ico">
+    <!-- Single Page Apps for GitHub Pages -->
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // https://github.com/rafgraph/spa-github-pages
+      // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
+      // ----------------------------------------------------------------------
+      // This script checks to see if a redirect is present in the query string,
+      // converts it back to the correct url and adds it to the
+      // browser's history using window.history.replaceState(...),
+      // which won't cause the browser to attempt to load the new url.
+      // When the single page app is loaded further down in this file,
+      // the correct url will be waiting in the browser's history for
+      // the single page app to route accordingly.
+      (function(l) {
+        if (l.search[1] === '/' ) {
+          var decoded = l.search.slice(1).split('&').map(function(s) { 
+            return s.replace(/~and~/g, '&')
+          }).join('?');
+          window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      }(window.location))
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-D9TV03G0G6"></script>
     <script>

--- a/frontend/public/404.html
+++ b/frontend/public/404.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>LLM Domain Classification</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // https://github.com/rafgraph/spa-github-pages
+      // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
+      // ----------------------------------------------------------------------
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+
+      // If you're creating a Project Pages site and NOT using a custom domain,
+      // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+      // This way the code will only replace the route part and not the real directory.
+      // For example: https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+      // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+      // Otherwise, leave pathSegmentsToKeep as 0.
+      var pathSegmentsToKeep = 1;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,7 +3,9 @@ import { RouterView } from 'vue-router'
 </script>
 
 <template>
-    <RouterView />
+    <div class="min-h-screen flex flex-col">
+        <RouterView />
+    </div>
 </template>
 
 <style>

--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer class="footer footer-center p-4 mt-4 bg-neutral text-white">
+  <footer class="footer footer-center p-4 mt-auto bg-neutral text-white">
     <div class="container">
       <div class="grid grid-flow-col gap-4">
         <router-link to="/about" class="link link-hover">About</router-link>

--- a/frontend/src/components/ModelResults.vue
+++ b/frontend/src/components/ModelResults.vue
@@ -110,7 +110,7 @@ const isWithinMonth = (dateStr) => {
 </script>
 
 <template>
-  <div class="space-y-8">
+  <div class="space-y-8 mb-8">
     <!-- Correlation Results Table -->
     <h1 class="text-3xl text-center font-bold my-6">Accuracy and political bias of news source credibility ratings by large language models</h1>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7,11 +7,11 @@ import router from './router'
 // Import Font Awesome
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { faEnvelope, faFilePdf, faCopy, faBrain } from '@fortawesome/free-solid-svg-icons'
+import { faEnvelope, faFilePdf, faCopy, faBrain, faExternalLinkAlt, faLink } from '@fortawesome/free-solid-svg-icons'
 import { faXTwitter, faGithub } from '@fortawesome/free-brands-svg-icons'
 
 // Add icons to the library
-library.add(faEnvelope, faXTwitter, faFilePdf, faGithub, faCopy, faBrain)
+library.add(faEnvelope, faXTwitter, faFilePdf, faGithub, faCopy, faBrain, faExternalLinkAlt, faLink)
 
 const app = createApp(App)
 

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -7,9 +7,9 @@ const { companyLogos } = useCompanyLogos()
 </script>
 
 <template>
-  <div>
+  <div class="flex flex-col min-h-screen">
     <NavBar />
-    <div class="container mx-auto">
+    <div class="container mx-auto flex-grow">
       <div class="flex items-center gap-8 mb-8 justify-center">
         <div class="flex-shrink-0">
           <img :src="companyLogos.logo" alt="Logo" class="h-25 inline-block mt-5" />

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -5,9 +5,9 @@ import NavBar from '@/components/NavBar.vue'
 </script>
 
 <template>
-  <div>
+  <div class="flex flex-col min-h-screen">
     <NavBar />
-    <div class="container mx-auto">
+    <div class="container mx-auto flex-grow">
       <ModelResults />
     </div>
     <Footer />

--- a/frontend/src/views/PaperRatingView.vue
+++ b/frontend/src/views/PaperRatingView.vue
@@ -45,17 +45,17 @@ const copyToClipboard = async () => {
       <!-- links -->
       <div class="text-center my-8">
         <div class="inline-flex flex-wrap gap-4 justify-center">
-          <a href="https://doi.org/10.1145/3717867.3717903" class="btn btn-outline border-neutral text-neutral hover:bg-neutral hover:text-white" target="_blank">
+          <a href="https://doi.org/10.1145/3717867.3717903" class="btn btn-outline border-neutral text-neutral hover:bg-neutral hover:text-white text-lg" target="_blank">
             <font-awesome-icon :icon="['fas', 'file-pdf']" class="mr-2" /> DOI
           </a>
-          <a href="https://arxiv.org/abs/2304.00228" class="btn btn-outline border-neutral text-neutral hover:bg-neutral hover:text-white" target="_blank">
+          <a href="https://arxiv.org/abs/2304.00228" class="btn btn-outline border-neutral text-neutral hover:bg-neutral hover:text-white text-lg" target="_blank">
             <font-awesome-icon :icon="['fas', 'file-pdf']" class="mr-2" /> arXiv
           </a>
-          <a href="https://github.com/osome-iu/llm_domain_rating" class="btn btn-outline border-neutral text-neutral hover:bg-neutral hover:text-white" target="_blank">
+          <a href="https://github.com/osome-iu/llm_domain_rating" class="btn btn-outline border-neutral text-neutral hover:bg-neutral hover:text-white text-lg" target="_blank">
             <font-awesome-icon :icon="['fab', 'github']" class="mr-2" /> GitHub
           </a>
-          <a href="https://x.com/yang3kc/status/1823404980126261262" class="btn btn-outline border-neutral text-neutral hover:bg-neutral hover:text-white" target="_blank">
-            <font-awesome-icon :icon="['fab', 'x-twitter']" class="mr-2" /> Twitter thread
+          <a href="https://x.com/yang3kc/status/1823404980126261262" class="btn btn-outline border-neutral text-neutral hover:bg-neutral hover:text-white text-lg" target="_blank">
+            <font-awesome-icon :icon="['fab', 'x-twitter']" class="mr-2" /> Twitter
           </a>
         </div>
       </div>

--- a/frontend/src/views/PaperRatingView.vue
+++ b/frontend/src/views/PaperRatingView.vue
@@ -33,9 +33,9 @@ const copyToClipboard = async () => {
 </script>
 
 <template>
-  <div>
+  <div class="flex flex-col min-h-screen">
     <NavBar />
-    <div class="container mx-auto">
+    <div class="container mx-auto flex-grow">
       <!-- title  -->
       <div class="prose-h1 prose-2xl prose-slate text-center font-bold mt-6">Accuracy and political bias of news source credibility ratings by large language models</div>
       <!-- authors -->

--- a/frontend/src/views/PaperRatingView.vue
+++ b/frontend/src/views/PaperRatingView.vue
@@ -43,19 +43,18 @@ const copyToClipboard = async () => {
          <a href="https://www.kaichengyang.me" class="link link-neutral" target="_blank">Kai-Cheng Yang</a> and <a href="https://cnets.indiana.edu/fil" class="link link-neutral" target="_blank">Filippo Menczer</a>
       </div>
       <!-- links -->
-      <div class="flex justify-center gap-4 my-4">
-        <div class="btn btn-neutral btn-outline">
-          <a href="https://arxiv.org/abs/2304.00228" class="text-neutral" target="_blank">
+      <div class="text-center my-8">
+        <div class="inline-flex flex-wrap gap-4 justify-center">
+          <a href="https://doi.org/10.1145/3717867.3717903" class="btn btn-outline border-neutral text-neutral hover:bg-neutral hover:text-white" target="_blank">
+            <font-awesome-icon :icon="['fas', 'file-pdf']" class="mr-2" /> DOI
+          </a>
+          <a href="https://arxiv.org/abs/2304.00228" class="btn btn-outline border-neutral text-neutral hover:bg-neutral hover:text-white" target="_blank">
             <font-awesome-icon :icon="['fas', 'file-pdf']" class="mr-2" /> arXiv
           </a>
-        </div>
-        <div class="btn btn-neutral btn-outline">
-          <a href="https://github.com/osome-iu/llm_domain_rating" class="text-neutral" target="_blank">
+          <a href="https://github.com/osome-iu/llm_domain_rating" class="btn btn-outline border-neutral text-neutral hover:bg-neutral hover:text-white" target="_blank">
             <font-awesome-icon :icon="['fab', 'github']" class="mr-2" /> GitHub
           </a>
-        </div>
-        <div class="btn btn-neutral btn-outline">
-          <a href="https://x.com/yang3kc/status/1823404980126261262" class="text-neutral" target="_blank">
+          <a href="https://x.com/yang3kc/status/1823404980126261262" class="btn btn-outline border-neutral text-neutral hover:bg-neutral hover:text-white" target="_blank">
             <font-awesome-icon :icon="['fab', 'x-twitter']" class="mr-2" /> Twitter thread
           </a>
         </div>
@@ -75,7 +74,7 @@ const copyToClipboard = async () => {
       </div>
       <!-- bib -->
       <div class="prose-h2 prose-xl prose-slate text-center font-bold my-4">Bibtex</div>
-      <div class="prose prose prose-slate max-w-none my-4 relative">
+      <div class="prose prose prose-slate max-w-none my-4 relative bibtex-container">
         <button
           @click="copyToClipboard"
           class="btn btn-sm btn-neutral absolute top-2 right-2"
@@ -105,7 +104,7 @@ code {
   white-space: pre;
 }
 
-.btn {
+.bibtex-container .btn {
   z-index: 10;
   position: absolute;
   top: 0.5rem;


### PR DESCRIPTION
## Summary
- Fix footer positioning to always stick to bottom of page
- Add DOI and arXiv links with icons to paper page  
- Increase font size for paper page link buttons
- Fix SPA routing for GitHub Pages direct URL access

## Changes Made
- **Footer positioning**: Implemented sticky footer using CSS flexbox across all views
- **Paper page links**: Added DOI, arXiv, GitHub, and Twitter links with FontAwesome icons
- **Button styling**: Increased font size with `text-lg` class while maintaining button dimensions
- **GitHub Pages routing**: Added 404.html redirect handler and URL processing script to fix direct URL access to routes like `/about`

## Test plan
- [x] Footer appears at bottom of page regardless of content length
- [x] Paper page displays all four link buttons with proper icons and styling
- [x] Button fonts are larger and more readable
- [x] GitHub Pages deployment should handle direct URL access without 404 errors

🤖 Generated with [Claude Code](https://claude.ai/code)